### PR TITLE
Queries

### DIFF
--- a/centralErros/src/main/java/com/projetoFinal/centralErros/controller/LogController.java
+++ b/centralErros/src/main/java/com/projetoFinal/centralErros/controller/LogController.java
@@ -39,4 +39,16 @@ public class LogController {
         logService.deleteUser(logId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
+    @GetMapping("/filter")
+    public ResponseEntity<?> findAllByEnvironmentOrderLevel(String env, String level) {
+        return new ResponseEntity <>(logService.findAllByEnvironmentOrderLevel(env, level), HttpStatus.OK);
+    }
+    @GetMapping("/filter")
+    public ResponseEntity<?> findAllByEnvironment(String env) {
+        return new ResponseEntity <>(logService.findAllByEnvironment(env), HttpStatus.OK);
+    }
+    @GetMapping("/filter")
+    public ResponseEntity<?> findAllOrderByLevel(String env) {
+        return new ResponseEntity <>(logService.findAllOrderByLevel(env), HttpStatus.OK);
+    }
 }

--- a/centralErros/src/main/java/com/projetoFinal/centralErros/repository/LogRepository.java
+++ b/centralErros/src/main/java/com/projetoFinal/centralErros/repository/LogRepository.java
@@ -4,6 +4,7 @@ import com.projetoFinal.centralErros.model.Log;
 import com.projetoFinal.centralErros.enums.EnvironmentEnum;
 import com.projetoFinal.centralErros.enums.LevelEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,13 +14,24 @@ import java.util.Optional;
 public interface LogRepository extends JpaRepository<Log, Long> {
 
     //traz todos os Logs baseado na opção que o usuário escolher nas caixas de seleção de environment e level
+
+    @Query(value = "Select l from Log l where l.environmentEnum=?1 order by l.levelEnum=?2")
     List<Log> findAllByEnvironmentOrderLevel(EnvironmentEnum env, LevelEnum levelEnum);
 
+    @Query(value = "Select l from Log l where l.environmentEnum=?1")
+    List<Log> findAllByEnvironment(EnvironmentEnum env);
+
     //traz os Logs baseado na pesquisa que o usuário fazer
+    @Query(value = "SELECT l FROM log l WHERE l.title LIKE '%?1%'",nativeQuery = true)
     List<Log> findAllBySearch(String search);
 
-    //traz todos os Logs arquivados (archieved == true)
+    @Query(value = "Select l from Log l where l.archived=true")
     List<Log> findAllByArchieved();
+
+
+    @Query(value = "Select l from Log l order by l.levelEnum=?2")
+    List<Log> findAllOrderByLevel(LevelEnum levelEnum);
+
 
     Optional<Log> findById(Long id);
 

--- a/centralErros/src/main/java/com/projetoFinal/centralErros/service/LogService.java
+++ b/centralErros/src/main/java/com/projetoFinal/centralErros/service/LogService.java
@@ -31,9 +31,15 @@ public class LogService {
     public void saveLog(Log log) {
         logRepository.save(log);
     }
-    public List<Log> findAllByEnvironmentOrderLevel(EnvironmentEnum env, LevelEnum levelEnum){
+    public List<Log> findAllOrderByLevel(String level){
+        return logRepository.findAllOrderByLevel(LevelEnum.valueOf(level));
+    }
+    public List<Log> findAllByEnvironment(String env){
+        return logRepository.findAllByEnvironment(EnvironmentEnum.valueOf(env));
+    }
+    public List<Log> findAllByEnvironmentOrderLevel(String env, String levelEnum){
 
-        return logRepository.findAllByEnvironmentOrderLevel(env,levelEnum);
+        return logRepository.findAllByEnvironmentOrderLevel(EnvironmentEnum.valueOf(env),LevelEnum.valueOf(levelEnum));
 
     }
 

--- a/centralErros/src/main/resources/application.properties
+++ b/centralErros/src/main/resources/application.properties
@@ -1,1 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:testdb?=ifNotExistsTrue
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
+spring.h2.console.enabled=true


### PR DESCRIPTION
Aplicação de queries para enums